### PR TITLE
Add `.cljc` extension

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -244,7 +244,7 @@
 
     ("\\.csx?$"         all-the-icons-alltheicon "csharp-line"          :face all-the-icons-dblue)
 
-    ("\\.clj$"          all-the-icons-alltheicon "clojure"              :height 1.0  :face all-the-icons-blue)
+    ("\\.cljc?$"        all-the-icons-alltheicon "clojure"              :height 1.0  :face all-the-icons-blue)
     ("\\.cljs$"         all-the-icons-alltheicon "clojure"              :height 1.0  :face all-the-icons-dblue)
 
     ("\\.coffee$"       all-the-icons-alltheicon "coffeescript"         :height 1.0  :face all-the-icons-maroon)


### PR DESCRIPTION
First of all, thanks for this package, my neotree is looking great :)

On to the issue itself, Clojure files can also have the `.cljc` extension, which stands for "common" code that can be shared between Clojure and ClojureScript.

Without this PR, those are not recognized by `all-the-icons`:
<img width="164" alt="screen shot 2016-09-19 at 16 06 40" src="https://cloud.githubusercontent.com/assets/661909/18637113/387d63a2-7e83-11e6-817f-5172386585bf.png">
