### PR TITLE
Interactive insertion functions

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -565,7 +565,7 @@ When F is provided, the info function is calculated with the format
 
   (defun all-the-icons--insert-function-name (name)
     "Get the symbol for an icon insert function for icon set NAME."
-    (intern (concat "all-the-icons-" (downcase (symbol-name name)) "-insert"))))
+    (intern (concat "all-the-icons-insert-" (downcase (symbol-name name))))))
 
 ;; Icon insertion functions
 

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -589,9 +589,9 @@ When F is provided, the info function is calculated with the format
                  (if show-family (format " %s" (symbol-name family))))))
             data)))
 
-(defun all-the-icons-insert (&optional family)
+(defun all-the-icons-insert (&optional arg family)
   "Interactive icon insertion function.  Choose from icons in family represented by symbol FAMILY."
-  (interactive)
+  (interactive "P")
   (let* ((candidates (if family
                          (all-the-icons--family-data-as-read-candidates family)
                        (apply
@@ -608,7 +608,12 @@ When F is provided, the info function is calculated with the format
          (icon-family (or family (intern (cadr selection))))
          (data-function (all-the-icons--function-name icon-family))
          (icon (funcall data-function icon-name)))
-    (insert icon)))
+    (cond
+     (arg
+      (let ((standard-output (current-buffer)))
+        (prin1 icon)))
+     (t
+      (insert icon)))))
 
 ;; Debug Helpers
 
@@ -655,9 +660,9 @@ FAMILY is the font family to use for the icons."
                              `(:family ,family :height ,height))
                      'display `(raise ,v-adjust)
                      'font-lock-ignore t)))
-     (defun ,(all-the-icons--insert-function-name name) ()
+     (defun ,(all-the-icons--insert-function-name name) (&optional arg)
        ,(format "Insert a %s icon at point." family)
-       (interactive) (all-the-icons-insert (quote ,name)))
+       (interactive "P") (all-the-icons-insert arg (quote ,name)))
      (add-to-list 'all-the-icons-font-families (quote ,name))))
 
 (define-icon alltheicon all-the-icons-data/alltheicons-alist "all-the-icons")

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -84,6 +84,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'font-lock+)
 
 (require 'data-alltheicons  "./data/data-alltheicons.el")
 (require 'data-faicons      "./data/data-faicons.el")
@@ -575,17 +576,17 @@ When F is provided, the info function is calculated with the format
               (let ((icon (cdr datum))
                     (icon-name (car datum)))
                 (concat
-                       ;; Add icon prefix to the entry.  'display property on the first character to
-                       ;; maintain match styling w/o adding foreign characters at the beginning of the line.
-                       ;; TODO: find a better method of doing this while maximizing compatibility with\
-                       ;; vanilla completing-read environments (i.e. no helm or ido).
-                       (propertize (substring icon-name 0 1) ;; TODO: 
-                                   'display (format "%s - %s" icon (substring icon-name 0 1)))
-                       (substring icon-name 1)
-                       ;; This would look best as demphasized parentheses, but vanilla environments with
-                       ;; sequential completion shouldn't have complicated / visually inconsistent completion
-                       ;; behavior.
-                       (if show-family (format " %s" (symbol-name family))))))
+                 ;; Add icon prefix to the entry.  'display property on the first character to
+                 ;; maintain match styling w/o adding foreign characters at the beginning of the line.
+                 ;; TODO: find a better method of doing this while maximizing compatibility with\
+                 ;; vanilla completing-read environments (i.e. no helm or ido).
+                 (propertize (substring icon-name 0 1)
+                             'display (format "%s - %s" (funcall (all-the-icons--function-name family) icon-name) (substring icon-name 0 1)))
+                 (substring icon-name 1)
+                 ;; This would look best as demphasized parentheses, but vanilla environments with
+                 ;; sequential completion shouldn't have complicated / visually inconsistent completion
+                 ;; behavior.
+                 (if show-family (format " %s" (symbol-name family))))))
             data)))
 
 (defun all-the-icons-insert (&optional family)
@@ -652,7 +653,8 @@ FAMILY is the font family to use for the icons."
                      'face (if other-face
                                `(:family ,family :height ,height :inherit ,other-face)
                              `(:family ,family :height ,height))
-                     'display `(raise ,v-adjust))))
+                     'display `(raise ,v-adjust)
+                     'font-lock-ignore t)))
      (defun ,(all-the-icons--insert-function-name name) ()
        ,(format "Insert a %s icon at point." family)
        (interactive) (all-the-icons-insert (quote ,name)))


### PR DESCRIPTION
Thanks for creating this library!  It is proving to be very useful and a huge time-saver :-)

This adds basic icon picker insertion functions for each font family (ex: `all-the-icons-alltheicon-insert`) and a generalized insertion function `all-the-icons-insert`.  The generalized insertion function includes all font families as candidates.

I personally use helm, but I sought to make this a compatible as possible with different environments.  There is no dependence on helm or ido and no special behavior for either.  As such-- the visuals are not appealing as the can be if special cases are introduced.

I followed your macro conventions and introduced `all-the-icons-font-families` to allow mapping across families.

The use the name macros in the functions may be questionable, but I wanted to avoid making `define-icon` any hairier.

What do you think?