### PR TITLE
Use correct XDG prefixed font path for font install function

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -681,7 +681,7 @@ When PFX is non-nil, ignore the prompt and just install"
   (when (or pfx (yes-or-no-p "This will download and install fonts, are you sure you want to do this?"))
     (let* ((url-format "https://github.com/domtronn/all-the-icons.el/blob/master/fonts/%s?raw=true")
            (font-dest (cl-case window-system
-                        (x  (concat (getenv "HOME") "/.fonts/"))                ;; Default Linux install directory
+                        (x  (concat (getenv "HOME") "/.local/share/fonts/"))    ;; Default Linux install directory
                         (ns (concat (getenv "HOME") "/Library/Fonts/" ))))      ;; Default MacOS install directory
            (known-dest? (stringp font-dest)))
       (unless font-dest

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -681,8 +681,8 @@ When PFX is non-nil, ignore the prompt and just install"
   (when (or pfx (yes-or-no-p "This will download and install fonts, are you sure you want to do this?"))
     (let* ((url-format "https://github.com/domtronn/all-the-icons.el/blob/master/fonts/%s?raw=true")
            (font-dest (cl-case window-system
-                        (x  (concat (getenv "HOME") "/.local/share/fonts/"))    ;; Default Linux install directory
-                        (ns (concat (getenv "HOME") "/Library/Fonts/" ))))      ;; Default MacOS install directory
+                        (x  (concat (getenv "XDG_DATA_HOME") "/fonts/"))    ;; Default Linux install directory
+                        (ns (concat (getenv "HOME") "/Library/Fonts/" ))))  ;; Default MacOS install directory
            (known-dest? (stringp font-dest)))
       (unless font-dest
         (setq font-dest (read-directory-name "Font installation directory: " "~/")))


### PR DESCRIPTION
The older `~/.fonts` directory has deprectated been deprecated in
fontconfig. These changes use the XDG prefixed font path instead. This
path resolves to `$XDG_DATA_HOME/fonts/`, with `$XDG_DATA_HOME` resolving
to `~/.local/share` if not set.

See following commit for `~/.fonts` deprecation:
http://cgit.freedesktop.org/fontconfig/tree/fonts.conf.in?id=d6a5cc665a1d7e91332944353e92c83ad114368c#n24

Also, I figure it might be nice for this function to create this directory if it doesn't exist.
What d'you think? If you agree, I might raise another PR for that :)