### PR TITLE
Support Homebrew Carbon Emacs

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -684,6 +684,7 @@ When PFX is non-nil, ignore the prompt and just install"
                         (x  (concat (or (getenv "XDG_DATA_HOME")            ;; Default Linux install directories
                                         (concat (getenv "HOME") "/.local/share"))
                                     "/fonts/"))
+                        (mac (concat (getenv "HOME") "/Library/Fonts/" ))
                         (ns (concat (getenv "HOME") "/Library/Fonts/" ))))  ;; Default MacOS install directory
            (known-dest? (stringp font-dest)))
       (unless font-dest


### PR DESCRIPTION
This port expose the old mac window-system constant, this change will give it support.

https://github.com/railwaycat/homebrew-emacsmacport