### PR TITLE
Add vue file extension

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -304,6 +304,7 @@
     ("\\.jsx$"          all-the-icons-fileicon "jsx-2"                  :height 0.8  :face all-the-icons-dyellow)
     ("\\.njs$"          all-the-icons-alltheicon "nodejs"               :height 1.2  :face all-the-icons-lgreen)
     ("^webpack"         all-the-icons-fileicon "webpack"                :face all-the-icons-lblue)
+    ("\\.vue$"          all-the-icons-fileicon "vue"                    :face all-the-icons-lgreen)
 
     ;; File Types
     ("\\.ico$"          all-the-icons-octicon "file-media"              :v-adjust 0.0 :face all-the-icons-blue)


### PR DESCRIPTION
This should add Vue icon in neotree, as far as I understand. I tried to verify that it works using quelpa github fetcher, but had an error. :( But change seem somewhat simple, I hope you don't mind non-checking PR.