### PR TITLE
all-the-icons-dir-icon-alist: Match `\\.git` only, not `.git`

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -360,7 +360,7 @@
     ("movies"           all-the-icons-faicon "film"             :height 0.9 :v-adjust -0.1)
     ("code"             all-the-icons-octicon "code"            :height 1.1 :v-adjust -0.1)
     ("workspace"        all-the-icons-octicon "code"            :height 1.1 :v-adjust -0.1)
-    (".git"             all-the-icons-alltheicon "git"          :height 1.0)
+    ("\\.git"           all-the-icons-alltheicon "git"          :height 1.0)
     ("."                all-the-icons-octicon "file-directory"  :height 1.0 :v-adjust -0.1)
     ))
 


### PR DESCRIPTION
Without this, any directory with "git" in its name would have had its icon set to the git icon, which is undesirable. Escape the dot in front of it so it only matches directories with a literal `.git` in their name.

For example, having a directory named `saggitarius` have the git icon is a little bit confusing.