### PR TITLE
Add support for various inky-rb file names.

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -284,10 +284,13 @@
     ("\\.hs$"           all-the-icons-alltheicon "haskell"              :height 1.0  :face all-the-icons-red)
 
     ;; Web modes
+    ("\\.inky-haml$"    all-the-icons-fileicon "haml"                   :face all-the-icons-lyellow)
     ("\\.haml$"         all-the-icons-fileicon "haml"                   :face all-the-icons-lyellow)
     ("\\.html?$"        all-the-icons-alltheicon "html5"                :face all-the-icons-orange)
+    ("\\.inky-erb?$"    all-the-icons-alltheicon "html5"                :face all-the-icons-lred)
     ("\\.erb$"          all-the-icons-alltheicon "html5"                :face all-the-icons-lred)
     ("\\.hbs$"          all-the-icons-fileicon "moustache"              :face all-the-icons-green)
+    ("\\.inky-slim$"    all-the-icons-octicon "dashboard"               :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.slim$"         all-the-icons-octicon "dashboard"               :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.jade$"         all-the-icons-fileicon "jade"                   :face all-the-icons-red)
     ("\\.pug$"          all-the-icons-fileicon "pug"                    :face all-the-icons-red)


### PR DESCRIPTION
This adds support for [inky-rb](https://github.com/zurb/inky-rb) file extensions:

* .inky-slim
* .inky-haml
* .inky-erb

I was not sure if it was better to add a second definition (the route I took) or to change the existing `.haml`, `.slim`, and `.erb` definitions to also match the `inky-` prefix. Happy to change anything.

Great project!