### PR TITLE
Make webpack priority higher

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -306,6 +306,7 @@
     ;; JavaScript
     ("^gulpfile"        all-the-icons-alltheicon "gulp"                 :height 1.0  :face all-the-icons-lred)
     ("^gruntfile"       all-the-icons-alltheicon "grunt"                :height 1.0 :v-adjust -0.1 :face all-the-icons-lyellow)
+    ("^webpack"         all-the-icons-fileicon "webpack"                :face all-the-icons-lblue)
 
     ("\\.d3\\.?js"      all-the-icons-alltheicon "d3"                   :height 0.8  :face all-the-icons-lgreen)
 
@@ -319,7 +320,6 @@
     ("\\.es[0-9]$"      all-the-icons-alltheicon "javascript"           :height 1.0 :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.jsx$"          all-the-icons-fileicon "jsx-2"                  :height 1.0 :v-adjust -0.1 :face all-the-icons-cyan-alt)
     ("\\.njs$"          all-the-icons-alltheicon "nodejs"               :height 1.2  :face all-the-icons-lgreen)
-    ("^webpack"         all-the-icons-fileicon "webpack"                :face all-the-icons-lblue)
     ("\\.vue$"          all-the-icons-fileicon "vue"                    :face all-the-icons-lgreen)
 
     ;; File Types


### PR DESCRIPTION
Most of the conventions of naming webpack config files are like this, and I think it'd be better to show them as webpack icons. 
But maybe there were some reasons to not to move them higher, or maybe I'm being out of touch.
![image](https://user-images.githubusercontent.com/10955264/28575066-7c2f9d9a-7158-11e7-95a5-baad73f5ed8c.png)
