### PR TITLE
Try to get icon from the parent mode.

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -172,7 +172,7 @@
     ;; ;; AWS
     ("^stack.*.json$"   all-the-icons-alltheicon "aws"                  :face all-the-icons-orange)
 
-    
+
     ("^serverless\\.yml$" all-the-icons-faicon "bolt"                   :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.[jc]son$"      all-the-icons-octicon "settings"                :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.ya?ml$"        all-the-icons-octicon "settings"                :v-adjust 0.0 :face all-the-icons-dyellow)
@@ -623,7 +623,8 @@ inserting functions."
 ARG-OVERRIDES should be a plist containining `:height',
 `:v-adjust' or `:face' properties like in the normal icon
 inserting functions."
-  (let* ((icon (cdr (assoc mode all-the-icons-mode-icon-alist)))
+  (let* ((icon (cdr (or (assoc mode all-the-icons-mode-icon-alist)
+                        (assoc (get mode 'derived-mode-parent) all-the-icons-mode-icon-alist))))
          (args (cdr icon)))
     (when arg-overrides (setq args (append `(,(car args)) arg-overrides (cdr args))))
     (if icon (apply (car icon) args) mode)))


### PR DESCRIPTION
There are major modes, which aren't supported by all-the-icons yet (e.g. `paradox-menu-mode`), but we can get icons from its parental mode (`package-menu-mode` in our case).