### PR TITLE
Fix wrong fonts being used when `font-lock-mode` is enabled

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -172,7 +172,7 @@
     ;; ;; AWS
     ("^stack.*.json$"   all-the-icons-alltheicon "aws"                  :face all-the-icons-orange)
 
-    
+
     ("^serverless\\.yml$" all-the-icons-faicon "bolt"                   :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.[jc]son$"      all-the-icons-octicon "settings"                :v-adjust 0.0 :face all-the-icons-yellow)
     ("\\.ya?ml$"        all-the-icons-octicon "settings"                :v-adjust 0.0 :face all-the-icons-dyellow)
@@ -808,13 +808,14 @@ FONT-NAME is the name of the .ttf file providing the font, defaults to FAMILY."
              (family ,family))
          (unless icon
            (error (format "Unable to find icon with name `%s' in icon set `%s'" icon-name (quote ,name))))
-         (propertize icon
-                     'face (if other-face
-                               `(:family ,family :height ,height :inherit ,other-face)
-                             `(:family ,family :height ,height))
-                     'display `(raise ,v-adjust)
-                     'rear-nonsticky t
-                     'font-lock-ignore t)))
+         (let ((face (if other-face
+                         `(:family ,family :height ,height :inherit ,other-face)
+                       `(:family ,family :height ,height))))
+           (propertize icon
+                       'face face           ;so that this works without `font-lock-mode' enabled
+                       'font-lock-face face ;so that `font-lock-mode' leaves this alone
+                       'display `(raise ,v-adjust)
+                       'rear-nonsticky t))))
      (defun ,(all-the-icons--insert-function-name name) (&optional arg)
        ,(format "Insert a %s icon at point." family)
        (interactive "P")


### PR DESCRIPTION
`font-lock+` was removed, so `font-lock-ignore` no longer works.

<img width="458" alt="font-lock-fix" src="https://user-images.githubusercontent.com/198359/35919555-13f99114-0c48-11e8-8d8a-25ff33507fa3.png">
