### PR TITLE
Add icons for mu4e major modes

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -449,6 +449,10 @@
     (magit-popup-mode          all-the-icons-alltheicon "git"              :face all-the-icons-red)
     (magit-status-mode         all-the-icons-alltheicon "git"              :face all-the-icons-lred)
     (magit-log-mode            all-the-icons-alltheicon "git"              :face all-the-icons-green)
+    (mu4e-compose-mode         all-the-icons-octicon "pencil"              :v-adjust 0.0)
+    (mu4e-headers-mode         all-the-icons-octicon "mail"                :v-adjust 0.0)
+    (mu4e-main-mode            all-the-icons-octicon "mail"                :v-adjust 0.0)
+    (mu4e-view-mode            all-the-icons-octicon "mail-read"           :v-adjust 0.0)
     (Custom-mode               all-the-icons-octicon "settings")
 
     ;; Special matcher for Web Mode based on the `web-mode-content-type' of the current buffer


### PR DESCRIPTION
I've added icons for the various mu4e major modes.

I couldn't tell if there was a preferred ordering in the alist so if you'd like these placed elsewhere in the list please let me know.

I'm also unsure about what the common practice is for assigning faces for new icons (I see most of the other mode icons have one). I don't have a preference for a custom face and just use these with the default colour in my mode-line, but can add them if needed.