### PR TITLE
Very simple fix for #127

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -557,7 +557,7 @@ and directory with PADDING.
 Produces different symbols by inspecting DIR to distinguish
 symlinks and git repositories which do not depend on the
 directory contents"
-  (let* ((matcher (all-the-icons-match-to-alist (file-name-base dir) all-the-icons-dir-icon-alist))
+  (let* ((matcher (all-the-icons-match-to-alist (file-name-base (directory-file-name dir)) all-the-icons-dir-icon-alist))
          (path (expand-file-name dir))
          (chevron (if chevron (all-the-icons-octicon (format "chevron-%s" chevron) :height 0.8 :v-adjust -0.1) ""))
          (padding (or padding "\t"))


### PR DESCRIPTION
With this change, directories can now be given with trailing slash and
the proper icon  will be returned. If the PR gets merged, #127 can be closed.