### PR TITLE
Update the GitHub URL used when installing

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -848,7 +848,7 @@ If SHOW-FAMILY is non-nil, displays the icons family in the candidate string."
 When PFX is non-nil, ignore the prompt and just install"
   (interactive "P")
   (when (or pfx (yes-or-no-p "This will download and install fonts, are you sure you want to do this?"))
-    (let* ((url-format "https://github.com/domtronn/all-the-icons.el/blob/master/fonts/%s?raw=true")
+    (let* ((url-format "https://raw.githubusercontent.com/domtronn/all-the-icons.el/master/fonts/%s")
            (font-dest (cl-case window-system
                         (x  (concat (or (getenv "XDG_DATA_HOME")            ;; Default Linux install directories
                                         (concat (getenv "HOME") "/.local/share"))


### PR DESCRIPTION
This fixes https://github.com/domtronn/all-the-icons.el/issues/134

The previous URL results in a 302 redirect from GitHub to the new URL. However this is not followed and results in empty files being written for each font instead of the actual font file.