### PR TITLE
Use Terraform icon for *.tf, *.tfvars, and *.tfstate files

### DIFF
--- a/all-the-icons-faces.el
+++ b/all-the-icons-faces.el
@@ -136,6 +136,11 @@
     (((background light)) :foreground "#68295B"))
   "Face for purple icons"
   :group 'all-the-icons-faces)
+(defface all-the-icons-purple-alt
+  '((((background dark)) :foreground "#5D54E1")
+    (((background light)) :foreground "#5D54E1"))
+  "Face for purple icons"
+  :group 'all-the-icons-faces)
 (defface all-the-icons-lpurple
   '((((background dark)) :foreground "#E69DD6")
     (((background light)) :foreground "#E69DD6"))

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -255,6 +255,8 @@
     ("-?spec\\."        all-the-icons-fileicon "test-generic"           :height 1.0 :v-adjust 0.0 :face all-the-icons-dgreen)
     ("-?test\\."        all-the-icons-fileicon "test-generic"           :height 1.0 :v-adjust 0.0 :face all-the-icons-dgreen)
 
+    ("\\.tf\\(vars\\|state\\)?$" all-the-icons-fileicon "terraform"     :height 1.0 :face all-the-icons-purple-alt)
+
     ;; There seems to be a a bug with this font icon which does not
     ;; let you propertise it without it reverting to being a lower
     ;; case phi


### PR DESCRIPTION
Support for HashiCorp Terraform files.

I also added a new purple for this, because the existing purple options were all pretty far off from the Terraform logo color. I can remove that if you don't want to proliferate the number of colors.