### PR TITLE
Replace non-existent face for paradox-menu-mode

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -456,7 +456,7 @@
     (magit-popup-mode          all-the-icons-alltheicon "git"              :face all-the-icons-red)
     (magit-status-mode         all-the-icons-alltheicon "git"              :face all-the-icons-lred)
     (magit-log-mode            all-the-icons-alltheicon "git"              :face all-the-icons-green)
-    (paradox-menu-mode         all-the-icons-faicon "archive"              :height 1.0 :v-adjust 0.0 :face all-the-icons-grey)
+    (paradox-menu-mode         all-the-icons-faicon "archive"              :height 1.0 :v-adjust 0.0 :face all-the-icons-silver)
     (Custom-mode               all-the-icons-octicon "settings")
 
     ;; Special matcher for Web Mode based on the `web-mode-content-type' of the current buffer


### PR DESCRIPTION
Paradox menu mode specifies all-the-icons-grey as its face and this does
not exist among the defined faces. Silver seems to be an ok substitution.