### PR TITLE
ruby-rspec: Use test-ruby icon for Ruby spec files

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -235,6 +235,8 @@
     ("\\.gem$"          all-the-icons-alltheicon "ruby-alt"             :face all-the-icons-red)
     ("_?test\\.rb$"        all-the-icons-fileicon "test-ruby"            :height 1.0 :v-adjust 0.0 :face all-the-icons-red)
     ("_?test_helper\\.rb$" all-the-icons-fileicon "test-ruby"            :height 1.0 :v-adjust 0.0 :face all-the-icons-dred)
+    ("_?spec\\.rb$"        all-the-icons-fileicon "test-ruby"            :height 1.0 :v-adjust 0.0 :face all-the-icons-red)
+    ("_?spec_helper\\.rb$" all-the-icons-fileicon "test-ruby"            :height 1.0 :v-adjust 0.0 :face all-the-icons-dred)
     ("\\.rb$"           all-the-icons-octicon "ruby"                    :v-adjust 0.0 :face all-the-icons-lred)
     ("\\.rs$"           all-the-icons-alltheicon "rust"                 :height 1.2  :face all-the-icons-maroon)
     ("\\.rlib$"         all-the-icons-alltheicon "rust"                 :height 1.2  :face all-the-icons-dmaroon)


### PR DESCRIPTION
Use `test-ruby` for Ruby's RSpec files

Before:
![image](https://user-images.githubusercontent.com/4923990/65981705-aabf8580-e447-11e9-9bf3-4e460e1cd5d9.png)

After:
![image](https://user-images.githubusercontent.com/4923990/65981714-aeeba300-e447-11e9-95ce-9aaaca7d6242.png)