### PR TITLE
Fix all-the-icons-for-dir argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ them manually.
 The simplest usage for this package is to use the following functions;
 
 -   `all-the-icons-icon-for-buffer`
+-   `all-the-icons-icon-for-dir`
 -   `all-the-icons-icon-for-file`
 -   `all-the-icons-icon-for-mode`
 -   `all-the-icons-icon-for-url`

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -49,6 +49,7 @@
 ;; The simplest usage for this package is to use the following functions;
 
 ;;   `all-the-icons-icon-for-buffer'
+;;   `all-the-icons-icon-for-dir'
 ;;   `all-the-icons-icon-for-file'
 ;;   `all-the-icons-icon-for-mode'
 ;;   `all-the-icons-icon-for-url'


### PR DESCRIPTION
Hi!
I found `all-the-icons-for-dir` function, but this function argument is a little strange.

- defun all-the-icons-icon-for-dir (dir &optional chevron padding)
- defun all-the-icons-icon-for-file (file &rest arg-overrides)
- defun all-the-icons-icon-for-mode (mode &rest arg-overrides)
- defun all-the-icons-icon-for-url (url &rest arg-overrides)

hmm, why `all-the-icons-icon-for-dir` doesn't have the same API as other functions?

I rename `all-the-icons-icon-for-dir` to `all-the-icon-for-dir-with-chevron`.
And fix `all-the-icons-icon-for-dir` argument have the same API than other function.


Certainly, the user has to change the function from `all-the-icons-icon-for-dir` to `all-the-icon-for-dir-with-chevron`, but I think that now gives the user a chance to make finer customization.