### PR TITLE
Clojure solid icon and green face for repl

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -327,7 +327,7 @@
 
     ("\\.csx?$"         all-the-icons-alltheicon "csharp-line"          :face all-the-icons-dblue)
 
-    ("\\.cljc?$"        all-the-icons-alltheicon "clojure-line"         :height 1.0 :face all-the-icons-blue :v-adjust 0.0)
+    ("\\.cljc?$"        all-the-icons-alltheicon "clojure"              :height 1.0 :face all-the-icons-blue :v-adjust 0.0)
     ("\\.cljs$"         all-the-icons-fileicon "cljs"                   :height 1.0 :face all-the-icons-dblue :v-adjust 0.0)
 
     ("\\.coffee$"       all-the-icons-alltheicon "coffeescript"         :height 1.0  :face all-the-icons-maroon)
@@ -578,8 +578,8 @@
     (c-mode                             all-the-icons-alltheicon "c-line"         :face all-the-icons-blue)
     (c++-mode                           all-the-icons-alltheicon "cplusplus-line" :v-adjust -0.2 :face all-the-icons-blue)
     (csharp-mode                        all-the-icons-alltheicon "csharp-line"    :face all-the-icons-dblue)
-    (clojure-mode                       all-the-icons-alltheicon "clojure-line"   :height 1.0  :face all-the-icons-blue)
-    (cider-repl-mode                    all-the-icons-alltheicon "clojure-line"   :height 1.0  :face all-the-icons-dblue)
+    (clojure-mode                       all-the-icons-alltheicon "clojure"        :height 1.0  :face all-the-icons-blue)
+    (cider-repl-mode                    all-the-icons-alltheicon "clojure"        :height 1.0  :face all-the-icons-green)
     (clojurescript-mode                 all-the-icons-fileicon "cljs"             :height 1.0  :face all-the-icons-dblue)
     (coffee-mode                        all-the-icons-alltheicon "coffeescript"   :height 1.0  :face all-the-icons-maroon)
     (lisp-mode                          all-the-icons-fileicon "lisp"             :face all-the-icons-orange)


### PR DESCRIPTION
Use the solid clojure icon version for Clojure, matching other modes such as Emacs,
markdown, etc, rather than the clojure-line icon.

The clojure icon has greater visibility that the clojure-line icon, so it is
easier to see the major mode at a glance.

Change REPL face to green, indicating a running Clojure process and providing a
subtle distinction between source and repl buffers.  This matches the face
used to indicate a running process in modeline themes.

Examples using the clojure icon
![all-the-icons-clojure-repl-doom-gruvbox-light](https://user-images.githubusercontent.com/250870/86614640-39e76400-bfab-11ea-88a0-5953b54bc3d8.png)
![all-the-icons-clojure-mode-doom-gruvbox-light](https://user-images.githubusercontent.com/250870/86614646-3a7ffa80-bfab-11ea-8a75-8a3df49b32c0.png)
![all-the-icons-clojure-mode-doom-gruvbox](https://user-images.githubusercontent.com/250870/86614650-3b189100-bfab-11ea-949b-a3ba1d5fccd0.png)
![all-the-icons-clojure-repl-doom-gruvbox](https://user-images.githubusercontent.com/250870/86614651-3b189100-bfab-11ea-9bc2-0ab49b406be8.png)
