### PR TITLE
Add the Jupyter icon to Interactive Python Notebooks

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -240,6 +240,7 @@
     ("\\.ps1$"          all-the-icons-fileicon "powershell"             :face all-the-icons-blue)
     ("\\.prol?o?g?$"    all-the-icons-alltheicon "prolog"               :height 1.1  :face all-the-icons-lmaroon)
     ("\\.py$"           all-the-icons-alltheicon "python"               :height 1.0  :face all-the-icons-dblue)
+    ("\\.ipynb$"        all-the-icons-fileicon "jupyter"                :height 1.0  :face all-the-icons-dorange)
 
     ("\\.rkt$"          all-the-icons-fileicon "racket"                 :height 1.2 :face all-the-icons-red)
     ("^Gemfile\\(\\.lock\\)?$" all-the-icons-alltheicon "ruby-alt"       :face all-the-icons-red)


### PR DESCRIPTION
The Jupyter icon is present in the font and the data, but it is not associated with any file extension. The `.ipynb` (Interactive PYthon NoteBook) is used by Jupyter for its files. This pull request simply associates the Jupyter icon with this file extension