### PR TITLE
Add version to define-obsolete-function-alias invocation

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1062,7 +1062,7 @@ FONT-NAME is the name of the .ttf file providing the font, defaults to FAMILY."
        (interactive "P")
        (all-the-icons-insert arg (quote ,name)))))
 
-(define-obsolete-function-alias 'define-icon 'all-the-icons-define-icon)
+(define-obsolete-function-alias 'define-icon 'all-the-icons-define-icon "4.0.0")
 
 (all-the-icons-define-icon alltheicon all-the-icons-data/alltheicons-alist    "all-the-icons")
 (all-the-icons-define-icon fileicon   all-the-icons-data/file-icon-alist      "file-icons")


### PR DESCRIPTION
The latest Emacs 28 requires this argument.