### PR TITLE
migrated casing from windows-system to system-type

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -999,12 +999,15 @@ When PFX is non-nil, ignore the prompt and just install"
   (interactive "P")
   (when (or pfx (yes-or-no-p "This will download and install fonts, are you sure you want to do this?"))
     (let* ((url-format "https://raw.githubusercontent.com/domtronn/all-the-icons.el/master/fonts/%s")
-           (font-dest (cl-case window-system
-                        (x  (concat (or (getenv "XDG_DATA_HOME")            ;; Default Linux install directories
-                                        (concat (getenv "HOME") "/.local/share"))
-                                    "/fonts/"))
-                        (mac (concat (getenv "HOME") "/Library/Fonts/" ))
-                        (ns (concat (getenv "HOME") "/Library/Fonts/" ))))  ;; Default MacOS install directory
+           (font-dest (cond
+                       ;; Default Linux install directories
+                       ((member system-type '(gnu gnu/linux gnu/kfreebsd))
+                        (concat (or (getenv "XDG_DATA_HOME")
+                                    (concat (getenv "HOME") "/.local/share"))
+                                "/fonts/"))
+                       ;; Default MacOS install directory
+                       ((eq system-type 'darwin)
+                        (concat (getenv "HOME") "/Library/Fonts/"))))
            (known-dest? (stringp font-dest))
            (font-dest (or font-dest (read-directory-name "Font installation directory: " "~/"))))
 


### PR DESCRIPTION
View [context](https://github.com/domtronn/all-the-icons.el/issues/237#issuecomment-774578010) in issue #237. 

Note I 'retained' most of the previous behavior. More clearly, I saw the previous casing didn't care about `w32` nor `pc`, so I didn't bother figuring out Windows casing either (cygwin might've been doable but I didn't have any way to double-check). I coupled all Linux casings to be one as the previous casing did, I think all of them should have the same directory but don't take my word for it. 

Someone should probably do a few tests :stuck_out_tongue: 