### PR TITLE
Recognise .Rmd files as markdown

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -433,7 +433,7 @@
     ("\\.te?xt$"        all-the-icons-octicon "file-text"               :v-adjust 0.0 :face all-the-icons-cyan)
     ("\\.doc[xm]?$"     all-the-icons-fileicon "word"                   :face all-the-icons-blue)
     ("\\.texi?$"        all-the-icons-fileicon "tex"                    :face all-the-icons-lred)
-    ("\\.md$"           all-the-icons-octicon "markdown"                :v-adjust 0.0 :face all-the-icons-lblue)
+    ("\\.r?md$"         all-the-icons-octicon "markdown"                :v-adjust 0.0 :face all-the-icons-lblue)
     ("\\.bib$"          all-the-icons-fileicon "bib"                    :face all-the-icons-maroon)
     ("\\.org$"          all-the-icons-fileicon "org"                    :face all-the-icons-lgreen)
 


### PR DESCRIPTION
Just a small tweak to match `.Rmd` as well as `.md` files for markdown.