### PR TITLE
Add GLSL file icons

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -325,6 +325,15 @@
     ;; Vagrant
     ("\\.vagrantfile$"   all-the-icons-fileicon "vagrant"               :face all-the-icons-blue)
     
+    ;; GLSL
+    ("\\.glsl$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-blue)
+    ("\\.vert$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-blue)
+    ("\\.tesc$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-purple)
+    ("\\.tese$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-dpurple)
+    ("\\.geom$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-green)
+    ("\\.frag$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-red)
+    ("\\.comp$"          all-the-icons-fileicon "vertex-shader"         :face all-the-icons-dblue)
+    
     ;; CUDA
     ("\\.cu$"            all-the-icons-fileicon "nvidia"                :face all-the-icons-green)
 


### PR DESCRIPTION
An icon for each shader file extension defined in [here](https://github.com/KhronosGroup/glslang), plus a generic .glsl extension.
The final result looks like this:
![image](https://user-images.githubusercontent.com/17773218/114151531-7de20d80-991d-11eb-9e33-158504a87f10.png)
