### PR TITLE
Lowered precedence of generic test files to prevent matching of more specific file types

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -266,9 +266,6 @@
     ("-?spec\\.jsx$"    all-the-icons-fileicon "test-react"             :height 1.0 :v-adjust 0.0 :face all-the-icons-blue-alt)
     ("-?test\\.jsx$"    all-the-icons-fileicon "test-react"             :height 1.0 :v-adjust 0.0 :face all-the-icons-blue-alt)
 
-    ("-?spec\\."        all-the-icons-fileicon "test-generic"           :height 1.0 :v-adjust 0.0 :face all-the-icons-dgreen)
-    ("-?test\\."        all-the-icons-fileicon "test-generic"           :height 1.0 :v-adjust 0.0 :face all-the-icons-dgreen)
-
     ("\\.tcl$"          all-the-icons-fileicon "tcl"                    :height 1.0 :face all-the-icons-dred)
 
     ("\\.tf\\(vars\\|state\\)?$" all-the-icons-fileicon "terraform"     :height 1.0 :face all-the-icons-purple-alt)


### PR DESCRIPTION
This ensures that e.g. ``greatest.jpg`` is matched as ``"file-media"`` whereas ``MyTest.xyz`` is still matched as ``"test-generic"``.