### PR TITLE
Add: CMake icons

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -159,6 +159,10 @@
     ("apache"           all-the-icons-alltheicon "apache"               :height 0.9  :face all-the-icons-dgreen)
     ("^Makefile$"       all-the-icons-fileicon "gnu"                    :face all-the-icons-dorange)
     ("\\.mk$"           all-the-icons-fileicon "gnu"                    :face all-the-icons-dorange)
+    ("^CMakeLists.txt$" all-the-icons-fileicon "cmake"                  :face all-the-icons-red)
+    ("^CMakeCache.txt$" all-the-icons-fileicon "cmake"                  :face all-the-icons-blue)
+    ("\\.cmake$"        all-the-icons-fileicon "cmake"                  :face all-the-icons-red)
+
 
     ("\\.dockerignore$" all-the-icons-fileicon "dockerfile"             :height 1.2  :face all-the-icons-dblue)
     ("^\\.?Dockerfile"  all-the-icons-fileicon "dockerfile"             :face all-the-icons-blue)

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -163,7 +163,6 @@
     ("^CMakeCache.txt$" all-the-icons-fileicon "cmake"                  :face all-the-icons-blue)
     ("\\.cmake$"        all-the-icons-fileicon "cmake"                  :face all-the-icons-red)
 
-
     ("\\.dockerignore$" all-the-icons-fileicon "dockerfile"             :height 1.2  :face all-the-icons-dblue)
     ("^\\.?Dockerfile"  all-the-icons-fileicon "dockerfile"             :face all-the-icons-blue)
     ("^Brewfile$"       all-the-icons-faicon "beer"                     :face all-the-icons-lsilver)
@@ -592,6 +591,7 @@
     (nginx-mode                         all-the-icons-fileicon "nginx"            :height 0.9  :face all-the-icons-dgreen)
     (apache-mode                        all-the-icons-alltheicon "apache"         :height 0.9  :face all-the-icons-dgreen)
     (makefile-mode                      all-the-icons-fileicon "gnu"              :face all-the-icons-dorange)
+    (cmake-mode                         all-the-icons-fileicon "cmake"            :face all-the-icons-red)
     (dockerfile-mode                    all-the-icons-fileicon "dockerfile"       :face all-the-icons-blue)
     (docker-compose-mode                all-the-icons-fileicon "dockerfile"       :face all-the-icons-lblue)
     (nxml-mode                          all-the-icons-faicon "file-code-o"        :height 0.95 :face all-the-icons-lorange)


### PR DESCRIPTION
Hi! Although I'm not that happy since the CMake icon consists of 3 colors, here I add icons for CMake-related files. They would look like this:

![image](https://user-images.githubusercontent.com/17773218/115967853-366e9a80-a535-11eb-97d7-c58043834479.png)

Please let me know of any feedback you may have.