### PR TITLE
Match file extensions in lower-case

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -158,7 +158,7 @@
     ("dat"          all-the-icons-faicon "bar-chart"          :face all-the-icons-cyan :height 0.9)
     ("dmg"          all-the-icons-octicon "tools"             :v-adjust 0.0 :face all-the-icons-lsilver)
     ("dll"          all-the-icons-faicon "cogs"               :face all-the-icons-silver)
-    ("DS_STORE"     all-the-icons-faicon "cogs"               :face all-the-icons-silver)
+    ("ds_store"     all-the-icons-faicon "cogs"               :face all-the-icons-silver)
     ;; Source Codes
     ("scpt"         all-the-icons-fileicon "apple"            :face all-the-icons-pink)
     ("aup"          all-the-icons-fileicon "audacity"         :face all-the-icons-yellow)
@@ -872,7 +872,7 @@ Note: You want chevron, please use `all-the-icons-icon-for-dir-with-chevron'."
 ARG-OVERRIDES should be a plist containining `:height',
 `:v-adjust' or `:face' properties like in the normal icon
 inserting functions."
-  (let* ((icon (or (cdr (assoc (file-name-extension file)
+  (let* ((icon (or (cdr (assoc (downcase (file-name-extension file))
                                all-the-icons-extension-icon-alist))
                    (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)))
          (args (cdr icon)))


### PR DESCRIPTION
Seems like the regexes previous to #228 were match case-insensetively, which I didn't take into account. 
This down-cases extentions before trying to match them which should take care of match misses with uppercase extentions.