### PR TITLE
Fixed icon for .rs-files

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -194,7 +194,6 @@
     ("r"            all-the-icons-fileicon "R"                :face all-the-icons-lblue)
     ("rd"           all-the-icons-fileicon "R"                :face all-the-icons-lblue)
     ("rdx"          all-the-icons-fileicon "R"                :face all-the-icons-lblue)
-    ("rs"           all-the-icons-fileicon "R"                :face all-the-icons-lblue)
     ("rsx"          all-the-icons-fileicon "R"                :face all-the-icons-lblue)
     ;; There seems to be a a bug with this font icon which does not
     ;; let you propertise it without it reverting to being a lower


### PR DESCRIPTION
Right now .rs files are displayed with the R logo.