### PR TITLE
Add the gentoo icon for .ebuild and .eclass files

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -170,6 +170,8 @@
     ("ex"           all-the-icons-alltheicon "elixir"         :face all-the-icons-lpurple :v-adjust -0.1 :height 0.9)
     ("exs"          all-the-icons-alltheicon "elixir"         :face all-the-icons-lred :v-adjust -0.1 :height 0.9)
     ("java"         all-the-icons-alltheicon "java"           :height 1.0  :face all-the-icons-purple)
+    ("ebuild"       all-the-icons-alltheicon "gentoo"         :face all-the-icons-cyan)
+    ("eclass"       all-the-icons-alltheicon "gentoo"         :face all-the-icons-blue)
     ("go"           all-the-icons-fileicon "go"               :height 1.0  :face all-the-icons-blue)
     ("jl"           all-the-icons-fileicon "julia"            :face all-the-icons-purple :v-adjust 0.0)
     ("matlab"       all-the-icons-fileicon "matlab"           :face all-the-icons-orange)

--- a/data/data-alltheicons.el
+++ b/data/data-alltheicons.el
@@ -20,6 +20,7 @@
     ( "dlang"              . "\xe935" )
     ( "elixir"             . "\xe936" )
     ( "erlang"             . "\xe934" )
+    ( "gentoo"             . "\xe96d" )
     ( "git"                . "\xe907" )
     ( "go"                 . "\xe91d" )
     ( "google-drive"       . "\xe91e" )


### PR DESCRIPTION
Based on: https://github.com/file-icons/atom/search?q=gentoo

Signed-off-by: Maciej Barć <xgqt@riseup.net>