### PR TITLE
Enhance performance with require file without extension

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -88,12 +88,12 @@
 ;;; Code:
 (require 'cl-lib)
 
-(require 'data-alltheicons  "./data/data-alltheicons.el")
-(require 'data-faicons      "./data/data-faicons.el")
-(require 'data-fileicons    "./data/data-fileicons.el")
-(require 'data-octicons     "./data/data-octicons.el")
-(require 'data-weathericons "./data/data-weathericons.el")
-(require 'data-material     "./data/data-material.el")
+(require 'data-alltheicons  "./data/data-alltheicons")
+(require 'data-faicons      "./data/data-faicons")
+(require 'data-fileicons    "./data/data-fileicons")
+(require 'data-octicons     "./data/data-octicons")
+(require 'data-weathericons "./data/data-weathericons")
+(require 'data-material     "./data/data-material")
 
 (require 'all-the-icons-faces)
 

--- a/test/all-the-icons-test.el
+++ b/test/all-the-icons-test.el
@@ -29,7 +29,7 @@
 (defvar all-the-icons--root-test (f-dirname (f-this-file)))
 (defvar all-the-icons--root-code (f-parent all-the-icons--root-test))
 
-(require 'all-the-icons (expand-file-name "all-the-icons.el" all-the-icons--root-code))
+(require 'all-the-icons (expand-file-name "all-the-icons" all-the-icons--root-code))
 
 (cl-loop
  for alist in (apropos-internal "^all-the-icons-[a-z\\-]*icon-alist$")


### PR DESCRIPTION
Hi, 

It's always requiring the `*.el` file while ignore the `*.elc` or `*.eln`. 
And it's also failed for some distrubution which only `*.el.gz` and `*.elc` are avaiable.
This patch try to fix these two issues.

Please help review this change. Thanks