### PR TITLE
Add .nosearch to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled
 *.elc
+all-the-icons-autoloads.el
 
 # Packaging
 .cask


### PR DESCRIPTION
Explanation from my commit message:

> Prevents (normal-top-level-add-subdirs-to-load-path) from adding test directory and subdirectories thereof to load-path. See Emacs help for normal-top-level-add-subdirs-to-load-path for more info.
>
> This allows users of the Borg package manager (and likely others) to enable recursive byte compilation instead of only byte-compiling files in the root of the project.

I also added the generated autoloads file to .gitignore.