### PR TITLE
feat: get icons from regex search first

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -473,8 +473,12 @@ for performance sake.")
     ("^\\*scratch.*"    all-the-icons-faicon "sticky-note"              :face all-the-icons-yellow)
     ("^\\*new-tab\\*$"  all-the-icons-material "star"                     :face all-the-icons-cyan)
 
-    ("^\\."             all-the-icons-octicon "gear"                    :v-adjust 0.0)
-    (".?"               all-the-icons-faicon "file-o"                   :v-adjust 0.0 :face all-the-icons-dsilver)))
+    ("^\\."             all-the-icons-octicon "gear"                    :v-adjust 0.0)))
+
+(defvar all-the-icons-default-icon '(all-the-icons-faicon "file-o" :v-adjust 0.0 :face all-the-icons-dsilver)
+	"Default icon to be used if none is found in:
+`all-the-icons-regexp-icon-alist' or `all-the-icons-extension-icon-alist'")
+
 
 (defvar all-the-icons-dir-icon-alist
   '(
@@ -878,12 +882,16 @@ Note: You want chevron, please use `all-the-icons-icon-for-dir-with-chevron'."
   "Get the formatted icon for FILE.
 ARG-OVERRIDES should be a plist containining `:height',
 `:v-adjust' or `:face' properties like in the normal icon
-inserting functions."
-  (let* ((ext (file-name-extension file))
-         (icon (or (and ext
-                        (cdr (assoc (downcase ext)
-                                    all-the-icons-extension-icon-alist)))
-                   (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)))
+inserting functions.
+It will search for icons in the following order:
+`all-the-icons-regexp-icon-alist'
+`all-the-icons-extension-icon-alist'
+If none is found it will use `all-the-icons-default-icon'."
+  (let* ((ext? (file-name-extension file))
+				 (ext (and ext? (downcase ext?)))
+         (icon (or (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)
+									 (assoc-default ext all-the-icons-extension-icon-alist)
+									 all-the-icons-default-icon))
          (args (cdr icon)))
     (when arg-overrides (setq args (append `(,(car args)) arg-overrides (cdr args))))
     (apply (car icon) args)))


### PR DESCRIPTION
# the problem
The function that searches for a icon given a filename `all-the-icons-icon-for-file` first searches for the icon in `all-the-icons-extension-icon-alist` and after in `all-the-icons-regexp-icon-alist`.

So files like `some-component.spec.ts` will be assigned to `all-the-icons-fileicon "typescript"` icon instead of `all-the-icons-fileicon "test-typescript"` defined in `all-the-icons-regexp-icon-alist`:

`("-?spec\\.ts$" all-the-icons-fileicon "test-typescript" :height 1.0 :v-adjust 0.0 :face all-the-icons-blue)`

Since regexes are more specifics than file extension, we should look into the regex alist first

# the solution

Invert the order of the `or` call inside `all-the-icons-icon-for-file`, searching first the regex alist.

In order to do that, I had to create a default icon `(all-the-icons-faicon "file-o" :v-adjust 0.0 :face all-the-icons-dsilver)` that was defined inside the regex alist as de default case:

`(".?" all-the-icons-faicon "file-o" :v-adjust 0.0 :face all-the-icons-dsilver)`

Now the `all-the-icons-icon-for-file` searches in the following order:
- `all-the-icons-regexp-icon-alist`
- `all-the-icons-extension-icon-alist`
-  if none is found, it gets the default icon.