### PR TITLE
Prioritise regexps over file extension lookups

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -419,8 +419,8 @@ for performance sake.")
 
     ;; Config
     ("^bower.json$"     all-the-icons-alltheicon "bower"                :height 1.0 :v-adjust 0.0 :face all-the-icons-lorange)
-    ("nginx"            all-the-icons-fileicon "nginx"                  :height 0.9  :face all-the-icons-dgreen)
-    ("apache"           all-the-icons-alltheicon "apache"               :height 0.9  :face all-the-icons-dgreen)
+    ("nginx$"            all-the-icons-fileicon "nginx"                  :height 0.9  :face all-the-icons-dgreen)
+    ("apache$"           all-the-icons-alltheicon "apache"               :height 0.9  :face all-the-icons-dgreen)
     ("^Makefile$"       all-the-icons-fileicon "gnu"                    :face all-the-icons-dorange)
     ("^CMakeLists.txt$" all-the-icons-fileicon "cmake"                  :face all-the-icons-red)
     ("^CMakeCache.txt$" all-the-icons-fileicon "cmake"                  :face all-the-icons-blue)
@@ -475,7 +475,10 @@ for performance sake.")
     ("^\\*new-tab\\*$"  all-the-icons-material "star"                     :face all-the-icons-cyan)
 
     ("^\\."             all-the-icons-octicon "gear"                    :v-adjust 0.0)
-    (".?"               all-the-icons-faicon "file-o"                   :v-adjust 0.0 :face all-the-icons-dsilver)))
+    ))
+
+(defvar all-the-icons-default-file-icon
+  '(all-the-icons-faicon "file-o" :v-adjust 0.0 :face all-the-icons-dsilver))
 
 (defvar all-the-icons-dir-icon-alist
   '(
@@ -882,10 +885,11 @@ ARG-OVERRIDES should be a plist containining `:height',
 `:v-adjust' or `:face' properties like in the normal icon
 inserting functions."
   (let* ((ext (file-name-extension file))
-         (icon (or (and ext
+         (icon (or (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)
+                   (and ext
                         (cdr (assoc (downcase ext)
                                     all-the-icons-extension-icon-alist)))
-                   (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)))
+                   all-the-icons-default-file-icon))
          (args (cdr icon)))
     (when arg-overrides (setq args (append `(,(car args)) arg-overrides (cdr args))))
     (apply (car icon) args)))


### PR DESCRIPTION
When looking for an icon for a given file name, `all-the-icons-icon-for-file` uses two sources of information in the following order:

1) `all-the-icons-extension-icon-alist`.
2) `all-the-icons-regexp-icon-alist`.

However, this might be incorrect in some cases when `all-the-icons-regexp-icon-alist` is used to particularise cases. For instance, with `bar_spec.rb` as input, `all-the-icons-icon-for-file` produces:

```lisp
ELISP> (all-the-icons-icon-for-file "bar_spec.rb")
 #("" 0 1
   (face
    (:family "github-octicons" :height 1.2 :inherit all-the-icons-lred)
    font-lock-face
    (:family "github-octicons" :height 1.2 :inherit all-the-icons-lred)
    display
    (raise 0.0)
    rear-nonsticky t))
```

Which is a "generic" Ruby file icon, however the association list that contains file name regexps has these elements:

```lisp
    ("_?test\\.rb$"        all-the-icons-fileicon "test-ruby" ...)
    ("_?test_helper\\.rb$" all-the-icons-fileicon "test-ruby" ...)
    ("_?spec\\.rb$"        all-the-icons-fileicon "test-ruby" ...)
    ("_?spec_helper\\.rb$" all-the-icons-fileicon "test-ruby" ...)
```
which help finding a better icon in this case. Unfortunately, 1) wins and 2) is never explored.

This patch fixes this issue by giving the regex match a higher priority than the file extension lookup. Also, to prevent the lookup from stopping by falling into the "fallback" match in 2), I'm moving the default to a separate variable.

With the patch applied, a better icon is returned in this case.

```lisp
ELISP> (all-the-icons-icon-for-file "bar_spec.rb")
 #("" 0 1
   (face
    (:family "file-icons" :height 1.2 :inherit all-the-icons-red)
    font-lock-face
    (:family "file-icons" :height 1.2 :inherit all-the-icons-red)
    display
    (raise 0.0)
    rear-nonsticky t))
```
I'm also anchoring a couple of elements to avoid giving wrong icons to files like `apache.rb` or `nginx.rb`.