### PR TITLE
Add icon for shorthand graphql file extension .gql

### DIFF
--- a/data/data-fileicons.el
+++ b/data/data-fileicons.el
@@ -176,6 +176,7 @@
     ( "godot" . "\xe974" )
     ( "golo" . "\xe979" )
     ( "gosu" . "\xe97a" )
+    ( "gql" . "\xe97c" )
     ( "gradle" . "\xe903" )
     ( "graphql" . "\xe97c" )
     ( "graphviz" . "\xe97d" )


### PR DESCRIPTION
This simply copies the existing graphql icon to also be applied to the shorthand form `.gql` files.