### PR TITLE
Add icon for man and woman

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -726,7 +726,8 @@ for performance sake.")
     (lilypond-mode                      all-the-icons-faicon   "music"            :face all-the-icons-green)
     (magik-session-mode                 all-the-icons-alltheicon "terminal"       :face all-the-icons-blue)
     (magik-cb-mode                      all-the-icons-faicon "book"               :face all-the-icons-blue)
-    (meson-mode                         all-the-icons-fileicon "meson"            :face all-the-icons-purple)))
+    (meson-mode                         all-the-icons-fileicon "meson"            :face all-the-icons-purple)
+    (man-common                         all-the-icons-fileicon "man-page"         :face all-the-icons-blue)))
 
 (defvar all-the-icons-url-alist
   '(


### PR DESCRIPTION
`man-common` is a parent mode of both.

```
λ> (let ((major-mode 'woman-mode)) (derived-mode-p 'man-common))
man-common
λ> (let ((major-mode 'Man-mode)) (derived-mode-p 'man-common))
man-common
```

![image](https://user-images.githubusercontent.com/131893/192805618-ca090f37-47e8-4f92-b391-61f3ce090156.png)

![image](https://user-images.githubusercontent.com/131893/192805662-09003302-61a4-4998-b675-22cc8df05d34.png)

![image](https://user-images.githubusercontent.com/131893/193101030-a563ef80-2fad-49a0-a2ba-81208b104aa1.png)
