### PR TITLE
Use the updated calling convention of sit-for

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1164,7 +1164,7 @@ pause for DURATION seconds between printing each character."
     (mapc
      (lambda (it)
        (insert (format "%s - %s\n" (funcall insert-f (car it) :height height) (car it)))
-       (when duration (sit-for duration 0)))
+       (when duration (sit-for duration)))
      data)))
 
 (defmacro all-the-icons-define-icon (name alist family &optional font-name)


### PR DESCRIPTION
Because I was getting those warning all the time 
`all-the-icons/all-the-icons.el: Warning: Obsolete calling convention for 'sit-for'`.

The minimum supported Emacs version - 24.3 - also declared MILLISECONDS obsolete so changing this doesn't leave it behind.