### PR TITLE
Adding mjs file extension

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -277,6 +277,7 @@
     ("react"        all-the-icons-alltheicon "react"          :height 1.1  :face all-the-icons-lblue)
     ("ts"           all-the-icons-fileicon "typescript"       :height 1.0 :v-adjust -0.1 :face all-the-icons-blue-alt)
     ("js"           all-the-icons-alltheicon "javascript"     :height 1.0 :v-adjust 0.0 :face all-the-icons-yellow)
+    ("mjs"          all-the-icons-alltheicon "javascript"     :height 1.0 :v-adjust 0.0 :face all-the-icons-yellow)
     ("es"           all-the-icons-alltheicon "javascript"     :height 1.0 :v-adjust 0.0 :face all-the-icons-yellow)
     ("jsx"          all-the-icons-fileicon "jsx-2"            :height 1.0 :v-adjust -0.1 :face all-the-icons-cyan-alt)
     ("tsx"          all-the-icons-fileicon "tsx"              :height 1.0 :v-adjust -0.1 :face all-the-icons-cyan-alt)


### PR DESCRIPTION
This is used for module JavaScript files:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_%E2%80%94_.mjs_versus_.js