### PR TITLE
Support for .rasi files

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -155,6 +155,7 @@
     ("cson"         all-the-icons-octicon "settings"          :v-adjust 0.0 :face all-the-icons-yellow)
     ("yml"          all-the-icons-octicon "settings"          :v-adjust 0.0 :face all-the-icons-dyellow)
     ("yaml"         all-the-icons-octicon "settings"          :v-adjust 0.0 :face all-the-icons-dyellow)
+    ("rasi"         all-the-icons-octicon "settings"          :v-adjust 0.0 :face all-the-icons-dyellow)
     ;; ?
     ("pkg"          all-the-icons-octicon "package"           :v-adjust 0.0 :face all-the-icons-dsilver)
     ("rpm"          all-the-icons-octicon "package"           :v-adjust 0.0 :face all-the-icons-dsilver)
@@ -1042,7 +1043,7 @@ inserting functions."
 (defun all-the-icons-icon-family-for-file (file)
   "Get the icons font family for FILE."
   (let* ((ext (file-name-extension file))
-	     (icon (or (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)
+         (icon (or (all-the-icons-match-to-alist file all-the-icons-regexp-icon-alist)
                    (and ext
                         (cdr (assoc (downcase ext)
                                     all-the-icons-extension-icon-alist)))

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1017,7 +1017,7 @@ inserting functions."
   :type 'integer)
 
 (defun all-the-icons-cache (func)
-  "Set a cache for FUNC. Does not work on interactive functions."
+  "Set a cache for FUNC.  Does not work on interactive functions."
   (unless (get func 'all-the-icons--cached)
     (let ((cache (make-hash-table :test #'equal
                                   :size all-the-icons--cache-limit))


### PR DESCRIPTION
Given the `settings` icon to the `.rasi` extension. This extension is used by [Rofi](https://github.com/davatorium/rofi) for configuration files.