### PR TITLE
Remove obsolete define-icon that conflict with def inside icons.el

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1257,8 +1257,6 @@ FONT-NAME is the name of the .ttf file providing the font, defaults to FAMILY."
        (interactive "P")
        (all-the-icons-insert arg (quote ,name)))))
 
-(define-obsolete-function-alias 'define-icon 'all-the-icons-define-icon "4.0.0")
-
 (all-the-icons-define-icon alltheicon all-the-icons-data/alltheicons-alist    "all-the-icons")
 (all-the-icons-define-icon fileicon   all-the-icons-data/file-icon-alist      "file-icons")
 (all-the-icons-define-icon faicon     all-the-icons-data/fa-icon-alist        "FontAwesome")


### PR DESCRIPTION
This function has been deprecated for more than 4 years. Can we remove it now as it conflicts with `icons.el`'s `define-icon` and causes compilation error?