### PR TITLE
Elixir icon for livebook files

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -178,6 +178,7 @@
     ("heex"         all-the-icons-alltheicon "elixir"         :face all-the-icons-lorange :v-adjust -0.1 :height 0.9)
     ("ex"           all-the-icons-alltheicon "elixir"         :face all-the-icons-lpurple :v-adjust -0.1 :height 0.9)
     ("exs"          all-the-icons-alltheicon "elixir"         :face all-the-icons-lred :v-adjust -0.1 :height 0.9)
+    ("livemd"       all-the-icons-alltheicon "elixir"         :face all-the-icons-lblue :v-adjust -0.1 :height 0.9)
     ("java"         all-the-icons-alltheicon "java"           :height 1.0  :face all-the-icons-purple)
     ("gradle"       all-the-icons-fileicon "gradle"           :height 1.0  :face all-the-icons-silver)
     ("ebuild"       all-the-icons-fileicon "gentoo"           :face all-the-icons-cyan)


### PR DESCRIPTION
[Livebook](https://livebook.dev/) is a popular interactive notebook mixing elixir and markdown.  This adds an icon for the `.livemd` file extension.