### PR TITLE
Define icon for epub files

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -405,6 +405,7 @@
     ("docx"         all-the-icons-fileicon "word"             :face all-the-icons-blue)
     ("docm"         all-the-icons-fileicon "word"             :face all-the-icons-blue)
     ("eml"          all-the-icons-faicon "envelope"              :face all-the-icons-blue)
+    ("epub"         all-the-icons-faicon "book"               :face all-the-icons-blue)
     ("msg"          all-the-icons-faicon "envelope"              :face all-the-icons-blue)
     ("texi"         all-the-icons-fileicon "tex"              :face all-the-icons-lred)
     ("tex"          all-the-icons-fileicon "tex"              :face all-the-icons-lred)


### PR DESCRIPTION
![image](https://github.com/domtronn/all-the-icons.el/assets/217543/0d80e12e-6897-4e54-b013-97bdbacfc724)
