### PR TITLE
ci: Replace Cask and add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 26.3
+          - 27.2
+          - 28.2
+          - 29.3
+        experimental: [false]
+        include:
+        - os: ubuntu-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: macos-latest
+          emacs-version: snapshot
+          experimental: true
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
+
+    - name: Run tests
+      run:
+        eask package
+        eask install
+        eask compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         version: 'snapshot'
 
     - name: Run tests
-      run:
+      run: |
         eask package
         eask install
         eask compile

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ all-the-icons-autoloads.el
 
 # Packaging
 .cask
+.eask
+
+/dist

--- a/Eask
+++ b/Eask
@@ -1,0 +1,22 @@
+(package "all-the-icons"
+         "5.0.0"
+         "A library for inserting Developer icons")
+
+(website-url "https://github.com/domtronn/all-the-icons.el")
+(keywords "convenient" "lisp")
+
+(package-file "all-the-icons.el")
+(files "*.el" "data/data-*.el")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source 'gnu)
+(source 'melpa)
+
+(depends-on "emacs" "24.3")
+
+(development
+  (depends-on "f")
+  (depends-on "ert-runner"))
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432


### PR DESCRIPTION
Cask is deprecated and no longer supports legacy Windows. 🤔 [Eask](https://github.com/emacs-eask/cli) is the replacement for Cask.

This patch added an Eask file and did the basic tests. WDYT?