### PR TITLE
all-the-icons.el: Add .S and .s file extension for assembly files and .ogx for volume

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -382,6 +382,7 @@
     ("wav"          all-the-icons-faicon "volume-up"          :face all-the-icons-dred)
     ("m4a"          all-the-icons-faicon "volume-up"          :face all-the-icons-dred)
     ("ogg"          all-the-icons-faicon "volume-up"          :face all-the-icons-dred)
+    ("ogx"          all-the-icons-faicon "volume-up"          :face all-the-icons-dred)
     ("flac"         all-the-icons-faicon "volume-up"          :face all-the-icons-dred)
     ("opus"         all-the-icons-faicon "volume-up"          :face all-the-icons-dred)
     ("au"           all-the-icons-faicon "volume-up"          :face all-the-icons-dred)

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -306,6 +306,8 @@
     ("tfstate"      all-the-icons-fileicon "terraform"        :height 1.0 :face all-the-icons-purple-alt)
 
     ("asm"          all-the-icons-fileicon "assembly"         :height 1.0 :face all-the-icons-blue)
+    ("s"            all-the-icons-fileicon "assembly"         :height 1.0 :face all-the-icons-blue)
+    ("S"            all-the-icons-fileicon "assembly"         :height 1.0 :face all-the-icons-blue)
     ;; Verilog(-AMS) and SystemVerilog(-AMS)
     ("v"            all-the-icons-fileicon "verilog"          :height 1.0 :v-adjust -0.2 :face all-the-icons-red)
     ("vams"         all-the-icons-fileicon "verilog"          :height 1.0 :v-adjust -0.2 :face all-the-icons-red)


### PR DESCRIPTION
`.S` and `.s` are common assembly file extensions.

Projects like the [Linux kernel](https://github.com/torvalds/linux/blob/master/arch/m68k/kernel/head.S) use `.S`.

And [Wikipedia](https://en.wikipedia.org/wiki/Assembly_language) also describes `.s` as a file extension.


Side-note: How could one collaborate on adding some new images. I couldn't find a concrete way to do so! (For further collaborations! :D)

Thanks in advance, have a nice week


Edit:

Regarding `.ogx` I downloaded some media file using firefox and I got an `.ogx`. [Here](https://en.wikipedia.org/wiki/Ogg)'s the wikipedia page where it mentions `.ogx` as an ogg file extension.