### PR TITLE
[SVG] Use the correct font size and make the size customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ to slightly adjust the way they're displayed.
 
 -   `:face` - The face to apply to the icon, defaults to `'default`
 -   `:padding` - The value to apply to the [`:margin`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Image-Descriptors.html) of the image property.
+-   `:size` - The size of the icon (defaults to the text height of the default face).
 
 So you would call, for example
 

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1167,11 +1167,7 @@ Return the icon file name if found."
 
 (defun all-the-icons-font-size (&optional face)
   "Returns the font size for the given FACE (or the default face if nil)."
-  (if-let* (((display-multi-font-p))
-            (info (font-info (face-font (or face 'default))))
-            (font-height (aref info 2)))
-      font-height
-    (frame-char-height)))
+  (aref (font-info (face-font (or face 'default))) 2))
 
 (cl-defmacro all-the-icons-define-icon (name alist &key svg-path-finder (svg-doc-processor ''identity) (padding 0))
   "Macro to generate functions for inserting icons for icon set NAME.

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1165,6 +1165,14 @@ Return the icon file name if found."
 
 (defconst all-the-icons--lib-dir (file-name-directory (locate-library "all-the-icons")))
 
+(defun all-the-icons-font-size (&optional face)
+  "Returns the font size for the given FACE (or the default face if nil)."
+  (if-let* (((display-multi-font-p))
+            (info (font-info (face-font (or face 'default))))
+            (font-height (aref info 2)))
+      font-height
+    (frame-char-height)))
+
 (cl-defmacro all-the-icons-define-icon (name alist &key svg-path-finder (svg-doc-processor ''identity) (padding 0))
   "Macro to generate functions for inserting icons for icon set NAME.
 
@@ -1189,7 +1197,7 @@ PADDING is the number of pixels to be applied to the SVG image."
      (defun ,(all-the-icons--data-name name) () ,alist)
      (defun ,(all-the-icons--function-name name) (icon-name &rest args)
        (let* ((file-name (all-the-icons--resolve-icon-file-name icon-name ,alist (quote ,name))) ;; remap icons
-              (size (window-default-font-height))
+              (size (or (plist-get args :size) (all-the-icons-font-size)))
               (lib-dir (concat all-the-icons--lib-dir ,(format "svg/%s/" name)))
               (image-path (concat lib-dir ,(or (and svg-path-finder
                                                     `(apply ,svg-path-finder file-name lib-dir size args))

--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -1167,7 +1167,18 @@ Return the icon file name if found."
 
 (defun all-the-icons-font-size (&optional face)
   "Returns the font size for the given FACE (or the default face if nil)."
-  (aref (font-info (face-font (or face 'default))) 2))
+  (if-let* ((font (face-font (or face 'default)))
+            (info (font-info font))
+            (font-size (aref info 2))
+            (font-height (aref info 3))
+            (height (cond
+                     ;; Prefer the font size, if specified and sane.
+                     ((and font-size (> font-size 0)) font-size)
+                     ;; Fallback on the font height otherwise.
+                     ((and font-height (> font-height 0)) font-height))))
+      height
+    ;; We fallback on the frame char height if we can't figure this out for some reason.
+    (frame-char-height)))
 
 (cl-defmacro all-the-icons-define-icon (name alist &key svg-path-finder (svg-doc-processor ''identity) (padding 0))
   "Macro to generate functions for inserting icons for icon set NAME.


### PR DESCRIPTION
I have two icon sizing issues with the `svg` branch:

1. I use a smaller font in my mode-line and tab-line, but also want to insert icons. This means I need a way to specify a size other than the height of the default face.
2. The font "height" (ascenders + descenders inclusive) of my default font ("JetBrains Mono") is 30 while the "size" (whatever that means) is 22. Unfortunately, inserting a 30px icon causes the line height to increase, making lines with icons taller. Setting the icon size to 22 fixes this.

So, I made a few changes in this patch:

1. Derive the icon size from the font size (where known), not the text height. Using the text height to make the line too large.
4. Make the `:size` configurable (to deal with buffers with multiple fonts/line heights).
5. Export the function that returns the correct font size of a face to make it easier to specify the correct icon size.