### PR TITLE
feat(filetypes): Add ClojureDart filetype

### DIFF
--- a/all-the-icons.el
+++ b/all-the-icons.el
@@ -243,6 +243,7 @@
     ("clj"          all-the-icons-alltheicon "clojure-line"   :height 1.0 :face all-the-icons-blue :v-adjust 0.0)
     ("cljc"         all-the-icons-alltheicon "clojure-line"   :height 1.0 :face all-the-icons-blue :v-adjust 0.0)
     ("cljs"         all-the-icons-fileicon "cljs"             :height 1.0 :face all-the-icons-dblue :v-adjust 0.0)
+    ("cljd"         all-the-icons-fileicon "cljs"             :height 1.0 :face all-the-icons-green :v-adjust 0.0)
     ("coffee"       all-the-icons-alltheicon "coffeescript"   :height 1.0  :face all-the-icons-maroon)
     ("iced"         all-the-icons-alltheicon "coffeescript"   :height 1.0  :face all-the-icons-lmaroon)
     ("dart"         all-the-icons-fileicon "dart"             :height 1.0 :face all-the-icons-blue :v-adjust 0.0)


### PR DESCRIPTION
Why?:
- ClojureDart is a new Clojure dialect that already gained some popularity and whose filetypes are currently missing.

This change addresses the need by:
- Add ClojureDart filetype .cljd